### PR TITLE
fix: Ensure two-column layout for main content area

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,10 @@
+html {
+  box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
+}
+
 body {
   font-family: Arial, Helvetica, sans-serif;
   margin: 0; /* Adjusted for full-width top-nav */


### PR DESCRIPTION
Addresses an issue where the left navigation panel and the right content panel were stacking vertically instead of displaying side-by-side.

The fix implements universal `box-sizing: border-box;` at the beginning of `style.css`. This ensures that padding and borders are included within the element's specified width and height, preventing common layout issues with Flexbox and other width-sensitive designs.

The two-column layout with a narrower left panel and a wider right content panel is now rendering as intended.